### PR TITLE
Use exact version (1.14.0) of Amplify package

### DIFF
--- a/brain-marks.xcodeproj/project.pbxproj
+++ b/brain-marks.xcodeproj/project.pbxproj
@@ -833,8 +833,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/aws-amplify/amplify-ios";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.8.0;
+				kind = exactVersion;
+				version = 1.14.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
Since this is an app and not a library, it's better to use exact versions of the dependencies to ensure correct behavior.

The latest 1.15.0 of the Amplify library doesn't compile on Xcode 12.5.1 or Xcode 13.
If it does compile and there is something wrong with my setup, feel free to reject this PR.