### PR TITLE
Add leading cancel-button to AddURLView

### DIFF
--- a/brain-marks/Add/AddURLView.swift
+++ b/brain-marks/Add/AddURLView.swift
@@ -31,6 +31,9 @@ struct AddURLView: View {
                 })
             }
             .navigationBarItems(
+                leading: Button("Cancel") {
+                    presentationMode.wrappedValue.dismiss()
+                },
                 trailing: Button("Save") {
                     if selectedCategory.name == "" {
                         viewModel.alertItem = AlertContext.noCategory


### PR DESCRIPTION
This PR adds a leading Cancel-button to the Navigationbar in AddURLView, which dismisses the Sheet programmatically, removing the need to swipe.