### PR TITLE
Feature/67: Enable user to change category order

### DIFF
--- a/brain-marks.xcodeproj/project.pbxproj
+++ b/brain-marks.xcodeproj/project.pbxproj
@@ -741,7 +741,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.1;
-				PRODUCT_BUNDLE_IDENTIFIER = com.aaronrichter.brainmarks;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mikaelacaron.brainmarks;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/brain-marks.xcodeproj/project.pbxproj
+++ b/brain-marks.xcodeproj/project.pbxproj
@@ -741,7 +741,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.1;
-				PRODUCT_BUNDLE_IDENTIFIER = com.mikaelacaron.brainmarks;
+				PRODUCT_BUNDLE_IDENTIFIER = com.aaronrichter.brainmarks;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";


### PR DESCRIPTION
This PR implements feature 67, which allows users to change the order of their categories. Upon change, the category is stored to UserDefaults, and when data is fetched from AWS, it is arranged back into this order.