### PR TITLE
Feature #66 leading swipe action

### DIFF
--- a/brain-marks.xcodeproj/project.pbxproj
+++ b/brain-marks.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		20636BDDDBEF4EAE9CCE9D9E /* amplifyconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = ECA1CF04DB754255822691F2 /* amplifyconfiguration.json */; };
+		372FE062281B778E00489F97 /* TweetCategoryList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 372FE061281B778E00489F97 /* TweetCategoryList.swift */; };
 		684E2F2D3FCC4D36AC68E57D /* AWSCategory+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551BA45F30D640118D2F0CE2 /* AWSCategory+Schema.swift */; };
 		91739DEB2622D2A7000F982A /* AddURLView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91739DEA2622D2A7000F982A /* AddURLView.swift */; };
 		91C8958926228D1500689196 /* Tweet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91C8958826228D1500689196 /* Tweet.swift */; };
@@ -78,6 +79,7 @@
 		0AA54EDF3B34443CA9D530E5 /* AWSTweet.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = AWSTweet.swift; path = amplify/generated/models/AWSTweet.swift; sourceTree = "<group>"; };
 		14F5BDE61EAA4A2DB9030734 /* AmplifyModels.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = AmplifyModels.swift; path = amplify/generated/models/AmplifyModels.swift; sourceTree = "<group>"; };
 		1E886624D4EE4F64B9160A75 /* amplifytools.xcconfig */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = text.xcconfig; path = amplifytools.xcconfig; sourceTree = "<group>"; };
+		372FE061281B778E00489F97 /* TweetCategoryList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TweetCategoryList.swift; sourceTree = "<group>"; };
 		551BA45F30D640118D2F0CE2 /* AWSCategory+Schema.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = "AWSCategory+Schema.swift"; path = "amplify/generated/models/AWSCategory+Schema.swift"; sourceTree = "<group>"; };
 		63D0518628EF45A382F08352 /* AWSCategory.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = AWSCategory.swift; path = amplify/generated/models/AWSCategory.swift; sourceTree = "<group>"; };
 		91739DEA2622D2A7000F982A /* AddURLView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddURLView.swift; sourceTree = "<group>"; };
@@ -302,6 +304,7 @@
 			children = (
 				A224A9E52622BCED00AC12AF /* TweetCard.swift */,
 				A205CD412622A3EB00517DB5 /* TweetList.swift */,
+				372FE061281B778E00489F97 /* TweetCategoryList.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -562,6 +565,7 @@
 				FF36B6712623678D007A6D7F /* AWSTweet+Extension.swift in Sources */,
 				D3F7C2EB27173EAC00DB87D9 /* String+Ext.swift in Sources */,
 				FFEBBB7626226A39000F475F /* Secrets.swift in Sources */,
+				372FE062281B778E00489F97 /* TweetCategoryList.swift in Sources */,
 				DB64F8A52726BD5D00361E86 /* Contributor.swift in Sources */,
 				A2F449912622829D00725FEA /* CategoryList.swift in Sources */,
 				A2F4498C2622802B00725FEA /* CategoryRow.swift in Sources */,

--- a/brain-marks/Categories/CategoryListViewModel.swift
+++ b/brain-marks/Categories/CategoryListViewModel.swift
@@ -14,12 +14,13 @@ final class CategoryListViewModel: ObservableObject {
     var lastEditedCategoryID = ""
     
     func getCategories() {
-        categories = []
         DataStoreManger.shared.fetchCategories { result in
             switch result {
             case .success(let categories):
                 DispatchQueue.main.async {
-                    self.categories = categories
+                    withAnimation {
+                        self.categories = categories
+                    }
                 }
             case .failure(let error):
                 print("Error fetching categories: \(error)")

--- a/brain-marks/Categories/Views/CategoryList.swift
+++ b/brain-marks/Categories/Views/CategoryList.swift
@@ -110,7 +110,7 @@ struct CategoryList: View {
     var categories: some View {
         List {
             ForEach(viewModel.categories) { category in
-                NavigationLink(destination: TweetList(category: category)) {
+                NavigationLink(destination: TweetList(category: category).environmentObject(viewModel)) {
                     CategoryRow(category: category)
                 }
                 .contextMenu {

--- a/brain-marks/Categories/Views/CategoryRow.swift
+++ b/brain-marks/Categories/Views/CategoryRow.swift
@@ -11,15 +11,7 @@ struct CategoryRow: View {
     let category: AWSCategory
 
     var body: some View {
-        HStack {
-            Image(systemName: category.imageName ?? "folder")
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .frame(width: 30, height: 30)
-                .font(Font.title.weight(.light))
-            Text(category.name)
-            Spacer()
-        }
+        Label(category.name, systemImage: category.imageName ?? "folder")
     }
 }
 

--- a/brain-marks/Categories/Views/CategorySheetView.swift
+++ b/brain-marks/Categories/Views/CategorySheetView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct CategorySheetView: View {
-    
+    @Binding var newCategoryCreated: Bool
     @Binding var editCategory: AWSCategory?
     @Binding var categorySheetState: CategoryState
     @ObservedObject var parentVM: CategoryListViewModel
@@ -21,6 +21,18 @@ struct CategorySheetView: View {
     @State private var categoryThumbnail = "folder"
     @State private var showCategoryGrid = false
     @StateObject private var viewModel = CategorySheetViewModel()
+
+    init(
+        newCategoryCreated: Binding<Bool> = .constant(false),
+        editCategory: Binding<AWSCategory?> = .constant(nil),
+        categorySheetState: Binding<CategoryState>,
+        parentVM: CategoryListViewModel
+    ) {
+        self._newCategoryCreated = newCategoryCreated
+        self._editCategory = editCategory
+        self._categorySheetState = categorySheetState
+        self.parentVM = parentVM
+    }
     
     var body: some View {
         NavigationView {
@@ -49,6 +61,7 @@ struct CategorySheetView: View {
                                     category: AWSCategory(name: category,
                                                           imageName: viewModel.thumbnail))
                                 }
+                                newCategoryCreated = true
                             case .edit:
                                 guard editCategory != nil else {
                                     return
@@ -58,9 +71,7 @@ struct CategorySheetView: View {
                                     category: editCategory!,
                                     newName: category, newThumbnail: categoryThumbnail)
                             }
-                        
                     } label: {
-                        
                         switch categorySheetState {
                         case .new: Text("Create")
                         case .edit: Text("Edit")

--- a/brain-marks/Managers/DataStoreManager.swift
+++ b/brain-marks/Managers/DataStoreManager.swift
@@ -110,8 +110,9 @@ class DataStoreManger {
     /// Moves tweet to a new category.
     ///
     /// - Parameters:
-    ///   - tweet: `AWSTweet` tweet to move
-    ///   - category: `AWSCategory` category to save tweet to
+    ///   - tweet: The tweet to be moved to another category
+    ///   - category: The category to move the tweet to
+    ///   - completion: A handler for when the code finishes
     func moveTweet(
         _ tweet: AWSTweet,
         to category: AWSCategory,

--- a/brain-marks/Tweets/TweetListViewModel.swift
+++ b/brain-marks/Tweets/TweetListViewModel.swift
@@ -17,7 +17,6 @@ final class TweetListViewModel: ObservableObject {
     /// - Parameters:
     ///     - category: The category to excluded from the list of retrieved categories
     func getCategories(whileExcluding category: AWSCategory? = nil) {
-        categories = []
         DataStoreManger.shared.fetchCategories { [weak self] result in
             switch result {
             case .success(let categories):

--- a/brain-marks/Tweets/TweetListViewModel.swift
+++ b/brain-marks/Tweets/TweetListViewModel.swift
@@ -12,6 +12,8 @@ final class TweetListViewModel: ObservableObject {
     @Published var tweets = [AWSTweet]()
     @Published var categories: [AWSCategory] = []
 
+    private(set) var newCategoryCreated = false
+
     /// Retrieves all categories with option to filter out a category.
     ///
     /// - Parameters:
@@ -29,6 +31,10 @@ final class TweetListViewModel: ObservableObject {
                 print("Error fetching categories: \(error)")
             }
         }
+    }
+
+    func updateNewCategoryCreated(_ update: Bool) {
+        newCategoryCreated = update
     }
     
     func fetchTweets(category: AWSCategory) {

--- a/brain-marks/Tweets/TweetListViewModel.swift
+++ b/brain-marks/Tweets/TweetListViewModel.swift
@@ -10,6 +10,32 @@ import SwiftUI
 final class TweetListViewModel: ObservableObject {
     
     @Published var tweets = [AWSTweet]()
+    @Published var categories: [AWSCategory] = []
+
+    /// When moving a tweet to another category, set this property
+    /// with the tweet's category that is being moved so it is excluded
+    /// from the list of categories the tweet can be moved to.
+    var excludedCategory: AWSCategory?
+
+    /// Retrieves all categories.
+    ///
+    /// If a value has been provided for the property `excludedCategory`, then
+    /// the categories list will not include that category.
+    func getCategories() {
+        categories = []
+        DataStoreManger.shared.fetchCategories { [weak self] result in
+            switch result {
+            case .success(let categories):
+                let filteredCategories = categories.filter { $0 != self?.excludedCategory }
+
+                DispatchQueue.main.async {
+                    self?.categories = filteredCategories
+                }
+            case .failure(let error):
+                print("Error fetching categories: \(error)")
+            }
+        }
+    }
     
     func fetchTweets(category: AWSCategory) {
         DataStoreManger.shared.fetchSavedTweets(for: category) { tweets in
@@ -18,7 +44,8 @@ final class TweetListViewModel: ObservableObject {
             }
         }
     }
-    
+
+    /// Pre iOS 15 way of deleting tweets—`IndexSet` is needed
     func deleteTweet(at offsets: IndexSet) {
         for _ in offsets {
             offsets.sorted(by: >).forEach { index in
@@ -27,6 +54,36 @@ final class TweetListViewModel: ObservableObject {
             }
         }
         tweets.remove(atOffsets: offsets)
+    }
+
+    /// iOS 15 * way of deleting tweet
+    func delete(_ tweet: AWSTweet) {
+        withAnimation {
+            tweets.removeAll(where: { $0.id == tweet.id })
+        }
+        
+        DataStoreManger.shared.deleteTweet(tweet)
+    }
+
+    var lastEditedCategoryID = ""
+
+    /// Move tweet to another category
+    func move(
+        _ tweet: AWSTweet,
+        to category: AWSCategory,
+        completion: @escaping (Result<AWSTweet, DataStoreManger.TweetError>) -> Void
+    ) {
+        DataStoreManger.shared.moveTweet(tweet, to: category) { [weak self] result in
+            switch result {
+            case .success(let updatedTweet):
+                withAnimation {
+                    self?.tweets.removeAll(where: { $0.id == tweet.id })
+                }
+                completion(.success(updatedTweet))
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
     }
     
     /// Opens Twitter app when tapping on tweet card

--- a/brain-marks/Tweets/TweetListViewModel.swift
+++ b/brain-marks/Tweets/TweetListViewModel.swift
@@ -12,21 +12,16 @@ final class TweetListViewModel: ObservableObject {
     @Published var tweets = [AWSTweet]()
     @Published var categories: [AWSCategory] = []
 
-    /// When moving a tweet to another category, set this property
-    /// with the tweet's category that is being moved so it is excluded
-    /// from the list of categories the tweet can be moved to.
-    var excludedCategory: AWSCategory?
-
-    /// Retrieves all categories.
+    /// Retrieves all categories with option to filter out a category.
     ///
-    /// If a value has been provided for the property `excludedCategory`, then
-    /// the categories list will not include that category.
-    func getCategories() {
+    /// - Parameters:
+    ///     - category: The category to excluded from the list of retrieved categories
+    func getCategories(whileExcluding category: AWSCategory? = nil) {
         categories = []
         DataStoreManger.shared.fetchCategories { [weak self] result in
             switch result {
             case .success(let categories):
-                let filteredCategories = categories.filter { $0 != self?.excludedCategory }
+                let filteredCategories = categories.filter { $0 != category }
 
                 DispatchQueue.main.async {
                     self?.categories = filteredCategories

--- a/brain-marks/Tweets/TweetListViewModel.swift
+++ b/brain-marks/Tweets/TweetListViewModel.swift
@@ -17,7 +17,7 @@ final class TweetListViewModel: ObservableObject {
     /// Retrieves all categories with option to filter out a category.
     ///
     /// - Parameters:
-    ///     - category: The category to excluded from the list of retrieved categories
+    ///     - category: The category to be excluded from the list of retrieved categories
     func getCategories(whileExcluding category: AWSCategory? = nil) {
         DataStoreManger.shared.fetchCategories { [weak self] result in
             switch result {

--- a/brain-marks/Tweets/Views/TweetCard.swift
+++ b/brain-marks/Tweets/Views/TweetCard.swift
@@ -10,16 +10,16 @@ import SwiftUI
 struct TweetCard: View {
     
     @State var tweet: AWSTweet
-    
+
     var body: some View {
-        VStack(alignment: .leading) {
+        VStack(alignment: .leading, spacing: 18) {
             TweetHeaderView(tweet: tweet)
             TweetBodyView(tweetBody: tweet.text!)
             if let timeStamp = tweet.timeStamp {
                 TimeStampView(timeStamp: timeStamp)
             }
-            //            TweetFooterView()
         }
+        .padding(.vertical)
     }
 }
 
@@ -35,7 +35,6 @@ struct TweetHeaderView: View {
                          userVerified: tweet.userVerified ?? false)
             Spacer()
         }
-        .padding(EdgeInsets(top: 18, leading: 18, bottom: 18, trailing: 18))
     }
 }
 
@@ -45,7 +44,6 @@ struct TweetBodyView: View {
         Text(tweetBody)
             .font(.body)
             .lineSpacing(8.0)
-            .padding(EdgeInsets(top: 0, leading: 18, bottom: 18, trailing: 18))
             .fixedSize(horizontal: false, vertical: true)
     }
 }
@@ -160,7 +158,6 @@ struct TimeStampView: View {
         Text(timeStamp.formatTimestamp())
             .font(.callout)
             .foregroundColor(.secondary)
-            .padding(.horizontal, 18)
     }
 }
 

--- a/brain-marks/Tweets/Views/TweetCategoryList.swift
+++ b/brain-marks/Tweets/Views/TweetCategoryList.swift
@@ -23,7 +23,6 @@ struct TweetCategoryList: View {
     init(tweet: AWSTweet, viewModel: TweetListViewModel) {
         self.tweet = tweet
         self.viewModel = viewModel
-        viewModel.excludedCategory = tweet.category
     }
 
     // MARK: - Body
@@ -41,7 +40,7 @@ struct TweetCategoryList: View {
                     }
                 }
         }
-        .onAppear { viewModel.getCategories() }
+        .onAppear { viewModel.getCategories(whileExcluding: tweet.category) }
     }
 
     // MARK: - Views

--- a/brain-marks/Tweets/Views/TweetCategoryList.swift
+++ b/brain-marks/Tweets/Views/TweetCategoryList.swift
@@ -1,0 +1,89 @@
+//
+//  TweetCategoryList.swift
+//  brain-marks
+//
+//  Created by Marlon Raskin on 4/28/22.
+//
+
+import SwiftUI
+
+struct TweetCategoryList: View {
+
+    // MARK: - Properties
+    let tweet: AWSTweet
+
+    @State private var selectedCategory: AWSCategory?
+    @State private var moveAlertMessage = ""
+
+    @ObservedObject private var viewModel: TweetListViewModel
+
+    @Environment(\.presentationMode) private var presentationMode
+
+    // MARK: - Init
+    init(tweet: AWSTweet, viewModel: TweetListViewModel) {
+        self.tweet = tweet
+        self.viewModel = viewModel
+        viewModel.excludedCategory = tweet.category
+    }
+
+    // MARK: - Body
+    var body: some View {
+        NavigationView {
+            List { ForEach(viewModel.categories, content: categoryRow) }
+                .navigationTitle("Categories")
+                .toolbar {
+                    ToolbarItem(placement: .navigationBarLeading) {
+                        Button("Cancel", action: dismiss)
+                    }
+                    ToolbarItem(placement: .navigationBarTrailing) {
+                        Button("Save", action: saveToTweetToCategory)
+                            .disabled(selectedCategory == nil)
+                    }
+                }
+        }
+        .onAppear { viewModel.getCategories() }
+    }
+
+    // MARK: - Views
+    private func categoryRow(category: AWSCategory) -> some View {
+        HStack {
+            Label(category.name, systemImage: category.imageName ?? "folder")
+                .foregroundColor(.primary)
+            Spacer()
+            if category == selectedCategory {
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundColor(.green)
+            }
+        }
+        .contentShape(Rectangle())
+        .onTapGesture {
+            selectedCategory = category
+        }
+    }
+
+    // MARK: - Helpers
+    private func dismiss() {
+        presentationMode.wrappedValue.dismiss()
+    }
+
+    private func saveToTweetToCategory() {
+        guard let selectedCategory = selectedCategory else { return }
+        viewModel.move(tweet, to: selectedCategory) { result in
+            switch result {
+            case .success(let tweet):
+                // Later we can show a success toast
+                print("Moved tweet: \(tweet)")
+                dismiss()
+            case .failure(let error):
+                // Later this message can be used for a failure toast
+                moveAlertMessage = error.localizedDescription
+            }
+        }
+    }
+}
+
+struct TweetCategoryList_Previews: PreviewProvider {
+    static var previews: some View {
+        TweetCategoryList(tweet: AWSTweet(tweetID: "tweet"), viewModel: TweetListViewModel())
+    }
+}

--- a/brain-marks/Tweets/Views/TweetCategoryList.swift
+++ b/brain-marks/Tweets/Views/TweetCategoryList.swift
@@ -79,7 +79,8 @@ struct TweetCategoryList: View {
                     .foregroundColor(.accentColor)
                     .padding(.all, 4)
                     .background(Color.accentColor.opacity(0.1))
-                    .cornerRadius(3)
+                    .cornerRadius(4)
+                    .overlay(RoundedRectangle(cornerRadius: 4).stroke(Color.accentColor, lineWidth: 0.3))
                 Spacer()
             }
         } else {

--- a/brain-marks/Tweets/Views/TweetCategoryList.swift
+++ b/brain-marks/Tweets/Views/TweetCategoryList.swift
@@ -82,6 +82,8 @@ struct TweetCategoryList: View {
                     .cornerRadius(3)
                 Spacer()
             }
+        } else {
+            Text("This tweet currently doesn't belong to any category.")
         }
     }
 

--- a/brain-marks/Tweets/Views/TweetCategoryList.swift
+++ b/brain-marks/Tweets/Views/TweetCategoryList.swift
@@ -32,46 +32,8 @@ struct TweetCategoryList: View {
     var body: some View {
         NavigationView {
             List {
-                Section {
-                    ForEach(viewModel.categories, content: categoryRow)
-                } footer: {
-                    if let category = tweet.category {
-                        HStack {
-                            Text("Currently in: ")
-                            Label(category.name, systemImage: category.imageName ?? "folder")
-                                .foregroundColor(.accentColor)
-                                .padding(.all, 4)
-                                .background(Color.accentColor.opacity(0.1))
-                                .cornerRadius(3)
-                            Spacer()
-                        }
-                    }
-                }
-
-                Section {
-                    Button {
-                        showingCategorySheet = true
-                    } label: {
-                        Label("New Category", systemImage: "plus")
-                            .foregroundColor(.accentColor)
-                    }
-                    .sheet(isPresented: $showingCategorySheet) {
-                        CategorySheetView(
-                            newCategoryCreated: $newCategoryCreated,
-                            editCategory: .constant(nil),
-                            categorySheetState: .constant(.new),
-                            parentVM: categoryListViewModel
-                        )
-                    }
-                    .onChange(of: showingCategorySheet) { showing in
-                        if !showing {
-                            if newCategoryCreated {
-                                viewModel.updateNewCategoryCreated(newCategoryCreated)
-                                viewModel.getCategories(whileExcluding: tweet.category)
-                            }
-                        }
-                    }
-                }
+                Section(content: categoryList, footer: categoryFooterView)
+                Section(content: newCategoryButton)
             }
             .navigationTitle("Categories")
             .toolbar {
@@ -88,6 +50,10 @@ struct TweetCategoryList: View {
     }
 
     // MARK: - Views
+    private func categoryList() -> some View {
+        ForEach(viewModel.categories, content: categoryRow)
+    }
+
     private func categoryRow(category: AWSCategory) -> some View {
         HStack {
             Label(category.name, systemImage: category.imageName ?? "folder")
@@ -101,6 +67,48 @@ struct TweetCategoryList: View {
         .contentShape(Rectangle())
         .onTapGesture {
             selectedCategory = category
+        }
+    }
+
+    @ViewBuilder
+    private func categoryFooterView() -> some View {
+        if let category = tweet.category {
+            HStack {
+                Text("Currently in: ")
+                Label(category.name, systemImage: category.imageName ?? "folder")
+                    .foregroundColor(.accentColor)
+                    .padding(.all, 4)
+                    .background(Color.accentColor.opacity(0.1))
+                    .cornerRadius(3)
+                Spacer()
+            }
+        }
+    }
+
+    private func createSheetView() -> CategorySheetView {
+        CategorySheetView(
+            newCategoryCreated: $newCategoryCreated,
+            editCategory: .constant(nil),
+            categorySheetState: .constant(.new),
+            parentVM: categoryListViewModel
+        )
+    }
+
+    private func newCategoryButton() -> some View {
+        Button {
+            showingCategorySheet = true
+        } label: {
+            Label("New Category", systemImage: "plus")
+                .foregroundColor(.accentColor)
+        }
+        .sheet(isPresented: $showingCategorySheet, content: createSheetView)
+        .onChange(of: showingCategorySheet) { showing in
+            if !showing {
+                if newCategoryCreated {
+                    viewModel.updateNewCategoryCreated(newCategoryCreated)
+                    viewModel.getCategories(whileExcluding: tweet.category)
+                }
+            }
         }
     }
 

--- a/brain-marks/Tweets/Views/TweetCategoryList.swift
+++ b/brain-marks/Tweets/Views/TweetCategoryList.swift
@@ -35,7 +35,7 @@ struct TweetCategoryList: View {
                         Button("Cancel", action: dismiss)
                     }
                     ToolbarItem(placement: .navigationBarTrailing) {
-                        Button("Save", action: saveToTweetToCategory)
+                        Button("Save", action: saveTweetToCategory)
                             .disabled(selectedCategory == nil)
                     }
                 }
@@ -65,7 +65,7 @@ struct TweetCategoryList: View {
         presentationMode.wrappedValue.dismiss()
     }
 
-    private func saveToTweetToCategory() {
+    private func saveTweetToCategory() {
         guard let selectedCategory = selectedCategory else { return }
         viewModel.move(tweet, to: selectedCategory) { result in
             switch result {

--- a/brain-marks/Tweets/Views/TweetList.swift
+++ b/brain-marks/Tweets/Views/TweetList.swift
@@ -13,6 +13,8 @@ struct TweetList: View {
     
     @StateObject var viewModel = TweetListViewModel()
     @State private var selectedTweet: AWSTweet?
+
+    @EnvironmentObject var categoryListViewModel: CategoryListViewModel
     
     var body: some View {
         tweetList
@@ -30,6 +32,11 @@ struct TweetList: View {
             }
             .onAppear {
                 viewModel.fetchTweets(category: category)
+            }
+            .onDisappear {
+                if viewModel.newCategoryCreated {
+                    categoryListViewModel.getCategories()
+                }
             }
     }
     


### PR DESCRIPTION
This PR implements Feature #66

## What it Does
Adds the ability to move a saved tweet to a different category while maintaining the delete functionality. Also adds the ability to create a new category when attempting to move the tweet to a new category. This is handy when one wants to move a tweet to a category they thought they already created but didn't. Instead of having to quit what you're doing, back out to the main categories screen to create a new category, then go back to where you were to move the tweet, this can all be done without interrupting your flow.

## How I Tested
1. Tap into a category that you know has tweets from the Categories List screen
2. Try swiping left to delete a tweet — the tweet should delete as expected
3. Try swiping right to move a tweet to a different category — Should present the Tweets Categories List (a new categories list screen)
4. Select from one of the categories and tap "Save"
5. The Tweets Category List should dismiss and the tweet should be removed from the tweets list for the currently viewed category
6. Swipe right on another tweet (full swipe should is allowed)
7. Tap "+ New Category" — Should present the `CategorySheetView` to create a new category
8. Name it, and select an icon if you want
9. Tap the "Create" button — The category sheet view will dismiss and the new category should be available as an option on the Tweets Category List screen.
10. Select the new category that was just created and tap "Save"
11. Navigate back to the main Categories List screen — You should see the new category animate onto the list

## Notes
- The `List` for the tweets was made into a plain list style to make the distinction clear as to what screen the user is looking at with a glance—can easily change this back
- The new category list that's used for moving tweets was kept as a grouped inset style list to match the rest of the app. Should feel right at home.
- When a new category is created, the main categories list screen should no longer flash before updating. The problem before was that every time `getCategories()` was called, the categories array was being set to an empty array first which was causing the empty state view to flash for a split second before the new data was populated. Now it just overwrites the categories array with the new data. It no longer sets it to an empty array anymore.
- There are other minor code cleanups with this PR as well — only for files that I was working in

## Screenshot
Here's a [link](https://cln.sh/Z9NOge) to the video that shows the new feature.