### PR TITLE
87 show images

### DIFF
--- a/amplify/backend/api/amplifyDatasource/schema.graphql
+++ b/amplify/backend/api/amplifyDatasource/schema.graphql
@@ -6,6 +6,7 @@ type AWSTweet @model {
     authorUsername: String
     profileImageURL: String
     category: AWSCategory @connection(name: "CategorizedTweet")
+    imageURL: String
 }
 
 type AWSCategory @model {

--- a/amplify/generated/models/AWSTweet+Schema.swift
+++ b/amplify/generated/models/AWSTweet+Schema.swift
@@ -12,6 +12,7 @@ extension AWSTweet {
     case authorUsername
     case profileImageURL
     case category
+    case imageURL
   }
   
   public static let keys = CodingKeys.self
@@ -29,7 +30,8 @@ extension AWSTweet {
       .field(aWSTweet.authorName, is: .optional, ofType: .string),
       .field(aWSTweet.authorUsername, is: .optional, ofType: .string),
       .field(aWSTweet.profileImageURL, is: .optional, ofType: .string),
-      .belongsTo(aWSTweet.category, is: .optional, ofType: AWSCategory.self, targetName: "awsTweetCategoryId")
+      .belongsTo(aWSTweet.category, is: .optional, ofType: AWSCategory.self, targetName: "awsTweetCategoryId"),
+      .field(aWSTweet.imageURL, is: .optional, ofType: .string)
     )
     }
 }

--- a/amplify/generated/models/AWSTweet.swift
+++ b/amplify/generated/models/AWSTweet.swift
@@ -3,27 +3,32 @@ import Amplify
 import Foundation
 
 public struct AWSTweet: Model {
-  public let id: String
-  public var tweetID: String
-  public var text: String?
-  public var authorName: String?
-  public var authorUsername: String?
-  public var profileImageURL: String?
-  public var category: AWSCategory?
-  
-  public init(id: String = UUID().uuidString,
-      tweetID: String,
-      text: String? = nil,
-      authorName: String? = nil,
-      authorUsername: String? = nil,
-      profileImageURL: String? = nil,
-      category: AWSCategory? = nil) {
-      self.id = id
-      self.tweetID = tweetID
-      self.text = text
-      self.authorName = authorName
-      self.authorUsername = authorUsername
-      self.profileImageURL = profileImageURL
-      self.category = category
-  }
+    public let id: String
+    public var tweetID: String
+    public var text: String?
+    public var authorName: String?
+    public var authorUsername: String?
+    public var profileImageURL: String?
+    public var category: AWSCategory?
+    public var imageURL: String?
+
+    public init(
+        id: String = UUID().uuidString,
+        tweetID: String,
+        text: String? = nil,
+        authorName: String? = nil,
+        authorUsername: String? = nil,
+        profileImageURL: String? = nil,
+        category: AWSCategory? = nil,
+        imageURL: String? = nil
+    ) {
+        self.id = id
+        self.tweetID = tweetID
+        self.text = text
+        self.authorName = authorName
+        self.authorUsername = authorUsername
+        self.profileImageURL = profileImageURL
+        self.category = category
+        self.imageURL = imageURL
+    }
 }

--- a/brain-marks.xcodeproj/project.pbxproj
+++ b/brain-marks.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		20636BDDDBEF4EAE9CCE9D9E /* amplifyconfiguration.json in Resources */ = {isa = PBXBuildFile; fileRef = ECA1CF04DB754255822691F2 /* amplifyconfiguration.json */; };
+		53C1D696282F535F00B34BCC /* TwitterAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53C1D695282F535F00B34BCC /* TwitterAPI.swift */; };
+		53C1D698283011DA00B34BCC /* TweetMedia.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53C1D697283011DA00B34BCC /* TweetMedia.swift */; };
 		684E2F2D3FCC4D36AC68E57D /* AWSCategory+Schema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551BA45F30D640118D2F0CE2 /* AWSCategory+Schema.swift */; };
 		91739DEB2622D2A7000F982A /* AddURLView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91739DEA2622D2A7000F982A /* AddURLView.swift */; };
 		91C8958926228D1500689196 /* Tweet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91C8958826228D1500689196 /* Tweet.swift */; };
@@ -67,6 +69,8 @@
 		0AA54EDF3B34443CA9D530E5 /* AWSTweet.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = AWSTweet.swift; path = amplify/generated/models/AWSTweet.swift; sourceTree = "<group>"; };
 		14F5BDE61EAA4A2DB9030734 /* AmplifyModels.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = AmplifyModels.swift; path = amplify/generated/models/AmplifyModels.swift; sourceTree = "<group>"; };
 		1E886624D4EE4F64B9160A75 /* amplifytools.xcconfig */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = text.xcconfig; path = amplifytools.xcconfig; sourceTree = "<group>"; };
+		53C1D695282F535F00B34BCC /* TwitterAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwitterAPI.swift; sourceTree = "<group>"; };
+		53C1D697283011DA00B34BCC /* TweetMedia.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TweetMedia.swift; sourceTree = "<group>"; };
 		551BA45F30D640118D2F0CE2 /* AWSCategory+Schema.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = "AWSCategory+Schema.swift"; path = "amplify/generated/models/AWSCategory+Schema.swift"; sourceTree = "<group>"; };
 		63D0518628EF45A382F08352 /* AWSCategory.swift */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 4; includeInIndex = 0; lastKnownFileType = sourcecode.swift; name = AWSCategory.swift; path = amplify/generated/models/AWSCategory.swift; sourceTree = "<group>"; };
 		91739DEA2622D2A7000F982A /* AddURLView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddURLView.swift; sourceTree = "<group>"; };
@@ -167,6 +171,7 @@
 				FF39431A262FCF4E00A3623B /* Includes.swift */,
 				FF39431F262FCF6100A3623B /* Response.swift */,
 				91C8958826228D1500689196 /* Tweet.swift */,
+				53C1D697283011DA00B34BCC /* TweetMedia.swift */,
 				FF394315262FCF3900A3623B /* User.swift */,
 				FFCB1096263E31D300544309 /* ReturnedTweet.swift */,
 			);
@@ -186,6 +191,7 @@
 			isa = PBXGroup;
 			children = (
 				FF5990682622DD61004DF328 /* DataStoreManager.swift */,
+				53C1D695282F535F00B34BCC /* TwitterAPI.swift */,
 			);
 			path = Managers;
 			sourceTree = "<group>";
@@ -474,6 +480,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				53C1D698283011DA00B34BCC /* TweetMedia.swift in Sources */,
 				91C8958926228D1500689196 /* Tweet.swift in Sources */,
 				FFEBBB3C26223F75000F475F /* ContentView.swift in Sources */,
 				A224A9E62622BCED00AC12AF /* TweetCard.swift in Sources */,
@@ -493,6 +500,7 @@
 				C0DAFC52B24C456EAE5AEF21 /* AWSCategory.swift in Sources */,
 				684E2F2D3FCC4D36AC68E57D /* AWSCategory+Schema.swift in Sources */,
 				FFBD2094269E7D090015131F /* AddURLViewModel.swift in Sources */,
+				53C1D696282F535F00B34BCC /* TwitterAPI.swift in Sources */,
 				CF16AFB9BE3F401E98C85114 /* AWSTweet.swift in Sources */,
 				FF36B661262357F9007A6D7F /* AWSCategory+Extension.swift in Sources */,
 				FF36B66C26235FE6007A6D7F /* TweetListViewModel.swift in Sources */,

--- a/brain-marks/Add/AddURLView.swift
+++ b/brain-marks/Add/AddURLView.swift
@@ -36,25 +36,12 @@ struct AddURLView: View {
                         viewModel.alertItem = AlertContext.noCategory
                         showingAlert = true
                     } else {
-                        viewModel.fetchTweet(url: newEntry) { result in
-                            switch result {
-                            case .success(let tweet):
-                                
-                                DataStoreManger.shared.fetchCategories { (result) in
-                                    if case .success(_) = result {
-                                        DataStoreManger.shared.createTweet(
-                                            tweet: tweet,
-                                            category: selectedCategory)
-                                    }
-                                    presentationMode.wrappedValue.dismiss()
-                                }
-                                
-                            case .failure(_):
-                                viewModel.alertItem = AlertContext.badURL
-                            }
+                        viewModel.saveTweet(url: newEntry, to: selectedCategory) {
+                            presentationMode.wrappedValue.dismiss()
                         }
                     }
-                })
+                }
+            )
         }
         .onAppear {
             DispatchQueue.main.async {

--- a/brain-marks/Managers/DataStoreManager.swift
+++ b/brain-marks/Managers/DataStoreManager.swift
@@ -65,7 +65,7 @@ class DataStoreManger {
     func deleteCategory(category: AWSCategory) {
         Amplify.DataStore.delete(category) { result in
             switch result {
-            case .success():
+            case .success:
                 print("✅ Deleted category")
             case .failure(let error):
                 print("❌ Could NOT delete category: \(error)")
@@ -111,7 +111,9 @@ class DataStoreManger {
                                 authorName: tweet.authorName,
                                 authorUsername: tweet.authorUsername,
                                 profileImageURL: tweet.profileImageURL,
-                                category: category)
+                                category: category,
+                                imageURL: tweet.imageURL
+        )
         
         Amplify.DataStore.save(awsTweet) { result in
             switch result {
@@ -134,8 +136,8 @@ class DataStoreManger {
             case .success(let categories):
                 
                 for selectedCategory in categories {
-                    if selectedCategory.name == category.name && selectedCategory.tweets != nil {
-                        completion(Array(selectedCategory.tweets!))
+                    if selectedCategory.name == category.name, let categoryTweets = selectedCategory.tweets {
+                        completion(Array(categoryTweets))
                     }
                 }
             case .failure(let error):
@@ -149,7 +151,7 @@ class DataStoreManger {
     func deleteTweet(_ tweet: AWSTweet) {
         Amplify.DataStore.delete(tweet) { result in
             switch result {
-            case .success():
+            case .success:
                 print("✅ Deleted tweet")
             case .failure(let error):
                 print("❌ Could NOT delete tweet: \(error)")

--- a/brain-marks/Managers/TwitterAPI.swift
+++ b/brain-marks/Managers/TwitterAPI.swift
@@ -1,0 +1,123 @@
+//
+//  TwitterAPI.swift
+//  brain-marks
+//
+//  Created by Andrew Erickson on 2022-05-13.
+//
+
+import Foundation
+
+class TwitterAPI {
+
+    private static let baseURL = "https://api.twitter.com/2/"
+
+    enum Endpoint: String {
+        case tweets
+    }
+
+    static func fetchTweet(
+        url urlString: String,
+        completion: @escaping (Result<ReturnedTweet, Error>) -> Void
+    ) {
+        guard
+            let url = URL(string: urlString),
+            let host = url.host,
+            host == "twitter.com"
+        else {
+            completion(.failure(HttpError.badURL))
+            return
+        }
+
+        let tweetId = url.lastPathComponent
+
+        guard let request = createFetchTweetRequest(tweetId: tweetId) else {
+            completion(.failure(HttpError.badRequest))
+            return
+        }
+
+        let task = URLSession.shared.dataTask(with: request) { data, response, error in
+            processResponse(data: data, response: response, error: error, completion: completion)
+        }
+        task.resume()
+    }
+
+    private static func processResponse(
+        data: Data?,
+        response: URLResponse?,
+        error: Error?,
+        completion: @escaping (Result<ReturnedTweet, Error>) -> Void
+    ) {
+        guard error == nil else {
+            completion(.failure(error!))
+            return
+        }
+
+        if let response = response as? HTTPURLResponse {
+            guard (200 ... 299) ~= response.statusCode else {
+                completion(.failure(HttpError.badResponse))
+                print("❌ Status code is \(response.statusCode)")
+                return
+            }
+
+            guard let data = data else {
+                completion(.failure(error!))
+                return
+            }
+
+            do {
+                let result = try JSONDecoder().decode(Response.self, from: data)
+
+                let user = result.includes.users.first
+
+                let authorName = user?.name ?? ""
+                let authorUsername = user?.username ?? ""
+                let profileImageURL = user?.profileImageURL.replacingOccurrences(
+                    of: "normal",
+                    with: "bigger") ?? ""
+                let data = result.data[0]
+                let photo = result.includes.media?.first(where: { $0.type == "photo" })
+
+                let tweetToSave = ReturnedTweet(
+                    id: data.id,
+                    text: data.text,
+                    authorName: authorName,
+                    authorUsername: authorUsername,
+                    profileImageURL: profileImageURL,
+                    imageURL: photo?.url
+                )
+
+                completion(.success(tweetToSave))
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    private static func createFetchTweetRequest(tweetId: String) -> URLRequest? {
+        guard var requestComponents = URLComponents(string: baseURL) else { return nil }
+
+        requestComponents.queryItems = [
+            URLQueryItem(name: "ids", value: tweetId),
+            URLQueryItem(name: "expansions", value: "author_id,attachments.media_keys"),
+            URLQueryItem(name: "user.fields", value: "profile_image_url"),
+            URLQueryItem(name: "media.fields", value: "type,url")
+        ]
+
+        guard let url = requestComponents.url else { return nil }
+
+        var request = URLRequest(
+            url: url.appendingPathComponent(Endpoint.tweets.rawValue),
+            timeoutInterval: Double.infinity
+        )
+        request.addValue("Bearer \(Secrets.bearerToken)", forHTTPHeaderField: "Authorization")
+        request.httpMethod = "GET"
+
+        return request
+    }
+}
+
+enum HttpError: Error {
+    case badResponse
+    case badURL
+    case badRequest
+}

--- a/brain-marks/Models/Includes.swift
+++ b/brain-marks/Models/Includes.swift
@@ -9,4 +9,5 @@ import Foundation
 
 struct Includes: Codable {
     let users: [User]
+    let media: [TweetMedia]?
 }

--- a/brain-marks/Models/ReturnedTweet.swift
+++ b/brain-marks/Models/ReturnedTweet.swift
@@ -13,4 +13,5 @@ struct ReturnedTweet: Codable {
     let authorName: String
     let authorUsername: String
     let profileImageURL: String
+    let imageURL: String?
 }

--- a/brain-marks/Models/TweetMedia.swift
+++ b/brain-marks/Models/TweetMedia.swift
@@ -1,0 +1,13 @@
+//
+//  TweetMedia.swift
+//  brain-marks
+//
+//  Created by Andrew Erickson on 2022-05-14.
+//
+
+import Foundation
+
+struct TweetMedia: Codable {
+    let url: String
+    let type: String
+}

--- a/brain-marks/Tweets/AsyncImage.swift
+++ b/brain-marks/Tweets/AsyncImage.swift
@@ -35,7 +35,9 @@ struct AsyncImage<Placeholder: View>: View {
     private var content: some View {
         Group {
             if loader.image != nil {
-                image(loader.image!).resizable()
+                image(loader.image!)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
             } else {
                 placeholder
             }

--- a/brain-marks/Tweets/Views/TweetCard.swift
+++ b/brain-marks/Tweets/Views/TweetCard.swift
@@ -14,7 +14,7 @@ struct TweetCard: View {
     var body: some View {
         VStack(alignment: .leading) {
             TweetHeaderView(tweet: tweet)
-            TweetBodyView(tweetBody: tweet.text!)
+            TweetBodyView(tweetBody: tweet.text!, imageURLString: tweet.imageURL)
 //            TweetFooterView()
         }
     }
@@ -37,11 +37,33 @@ struct TweetHeaderView: View {
 
 struct TweetBodyView: View {
     let tweetBody: String
+    let imageURLString: String?
+    var imageURL: URL? {
+        guard let imageURLString = imageURLString else {
+            return nil
+        }
+
+        return URL(string: imageURLString)
+    }
+
     var body: some View {
-        Text(tweetBody)
-            .font(.body)
-            .lineSpacing(8.0)
-            .padding(EdgeInsets(top: 0, leading: 18, bottom: 18, trailing: 18))
+        VStack {
+            Text(tweetBody)
+                .font(.body)
+                .lineSpacing(8.0)
+                .padding(EdgeInsets(top: 0, leading: 18, bottom: 18, trailing: 18))
+            if let imageURL = imageURL {
+                AsyncImage(
+                    url: imageURL,
+                    placeholder: {
+                        ProgressView()
+                            .progressViewStyle(CircularProgressViewStyle())
+                            .padding(64)
+                    }
+                )
+                    .padding(.horizontal)
+            }
+        }
     }
 }
 
@@ -146,7 +168,15 @@ struct UserInfoView: View {
 
 struct TweetCard_Previews: PreviewProvider {
     static var previews: some View {
-        TweetCard(tweet: AWSTweet(id: "123", tweetID: "234", text: "Tweet ext here"))
+        TweetCard(tweet: AWSTweet(
+            id: UUID().uuidString,
+            tweetID: "1450158883088093189",
+            text: "🍁 Apple Event October 2021 #sketchnote #AppleEvent",
+            authorName: "Feli #DieHimmelstraeumerin",
+            authorUsername: "felibe444",
+            profileImageURL: "https://pbs.twimg.com/profile_images/998112961666437120/_N6Pur3r_normal.jpg",
+            imageURL: "https://pbs.twimg.com/media/FB__0I6XMAIfx1Q.jpg"
+        ))
             .previewLayout(PreviewLayout.sizeThatFits)
     }
 }

--- a/brain-marks/Utilities/Alert.swift
+++ b/brain-marks/Utilities/Alert.swift
@@ -18,6 +18,9 @@ struct AlertContext {
     static let badURL = AlertItem(title: "❌",
                                   message: "The link you entered isn't valid.",
                                   dismissButon: .default(Text("OK")))
+    static let somethingWentWrong = AlertItem(title: "❌",
+                                  message: "Oops! Something went wrong.",
+                                  dismissButon: .default(Text("OK")))
     static let noCategory = AlertItem(title: "Uh oh!",
                                       message: "You must select a category",
                                       dismissButon: .default(Text("OK")))


### PR DESCRIPTION
Progress on issue #87 

## What it Does
- Adds images to tweets

## Changes made
- Updated the AWS models to include an optional `imageURL` for `AWSTweet`
- I've also refactored the Twitter requests out into a separate `TwitterAPI` file
- Made some improvements on how URLRequest is constructed using QueryItem
- Altered the valid url check slightly to check that the host is `twitter.com` instead of just checking for it anywhere in the url. This will prevent examples such as "https://someotherwebsite.com?param=twitter.com" from being detected as a valid url
- Added a distinction between a bad url error and bad request. The bad request can be presented to the user with a slightly different message instead of "The link you entered isn't valid". I ran into this case when I didn't have a twitter bearer token set up, as well as when I was making changes to the API request and had mistakes in the request format.
- Fixed a few SwiftLint warnings (maybe they're also fixed in another PR?)

## How I Tested
- A preview was added in `TweetCard` to make sure the layout looked good
- Tested adding both a tweet with an image and one without, both work as expected

## Notes
- I had to set up my own Twitter API key, AWS account and temporarily switch the team associated to signing but I made sure not to include any of that configuration in this PR

## Demo

https://user-images.githubusercontent.com/1420670/168443894-3cdd4b2f-c08a-4750-b5b5-af18dee684df.mov
