### PR TITLE
Preselect first category if there is one

### DIFF
--- a/brain-marks/Add/AddURLView.swift
+++ b/brain-marks/Add/AddURLView.swift
@@ -62,6 +62,10 @@ struct AddURLView: View {
                 })
         }
         .onAppear {
+            if let firstCategory = categories.first {
+                selectedCategory = firstCategory
+            }
+
             DispatchQueue.main.async {
                 newEntry = pasteBoard.string ?? ""
             }


### PR DESCRIPTION
Progress / Closed on issue #

## What it Does
* Fixes the category selection bug and closes #144 

## How I Tested
* Create a category
* Add a new tweet
* the first category is auto selected
* save tweet without alert