### PR TITLE
Refactor fetchTweet method to use async await

### DIFF
--- a/brain-marks/Add/AddURLView.swift
+++ b/brain-marks/Add/AddURLView.swift
@@ -41,10 +41,10 @@ struct AddURLView: View {
                         viewModel.alertItem = AlertContext.noCategory
                         showingAlert = true
                     } else {
-                        viewModel.fetchTweet(url: newEntry) { result in
-                            switch result {
-                            case .success(let tweet):
-                                
+                        Task(priority: .userInitiated) {
+                            do {
+                                let tweet = try await self.viewModel.fetchTweet(url: newEntry)
+
                                 DataStoreManger.shared.fetchCategories { (result) in
                                     if case .success = result {
                                         DataStoreManger.shared.createTweet(
@@ -53,9 +53,8 @@ struct AddURLView: View {
                                     }
                                     presentationMode.wrappedValue.dismiss()
                                 }
-                                
-                            case .failure:
-                                viewModel.alertItem = AlertContext.badURL
+                            } catch {
+                                self.viewModel.alertItem = AlertContext.badURL
                             }
                         }
                     }

--- a/brain-marks/Add/AddURLViewModel.swift
+++ b/brain-marks/Add/AddURLViewModel.swift
@@ -16,47 +16,24 @@ enum HttpError: Error {
 final class AddURLViewModel: ObservableObject {
     
     @Published var alertItem: AlertItem?
-    
-    func fetchTweet(url: String, completion: @escaping (Result<ReturnedTweet, Error>) -> Void) {
-        do {
-            let request = try createRequest(with: url)
-            
-            let task = URLSession.shared.dataTask(with: request) { [weak self] data, response, error in
-                
-                guard error == nil else {
-                    completion(.failure(error!))
-                    return
-                }
-                
-                if let response = response as? HTTPURLResponse {
-                    guard (200 ... 299) ~= response.statusCode else {
-                        completion(.failure(HttpError.badResponse))
-                        print("❌ Status code is \(response.statusCode)")
-                        return
-                    }
-                    
-                    guard let data = data else {
-                        completion(.failure(error!))
-                        return
-                    }
-                    
-                    do {
-                        let result = try JSONDecoder().decode(Response.self, from: data)
-                        
-                        guard let tweetToSave = self?.createTweet(result) else {
-                            completion(.failure(HttpError.cantDecode))
-                            return
-                        }
-                        
-                        completion(.success(tweetToSave))
-                    } catch {
-                        completion(.failure(error))
-                    }
-                }
+
+    func fetchTweet(url: String) async throws -> ReturnedTweet {
+        let (data, response) = try await URLSession.shared.data(for: createRequest(with: url))
+
+        if let response = response as? HTTPURLResponse {
+            guard (200 ... 299) ~= response.statusCode else {
+                print("❌ Status code is \(response.statusCode)")
+                throw HttpError.badResponse
             }
-            task.resume()
-        } catch {
-            completion(.failure(HttpError.badURL))
+
+            do {
+                let result = try JSONDecoder().decode(Response.self, from: data)
+                return self.createTweet(result)
+            } catch {
+                throw HttpError.cantDecode
+            }
+        } else {
+            throw HttpError.badResponse
         }
     }
     


### PR DESCRIPTION
## What it Does
* Refactor the `fetchTweet` method to use async/await instead of a completion handler

## Additional refactoring
* Think about creating an issue to refactor the methods in `DataStoreManger` to async/await

Closes #141 