### PR TITLE
add spanish localization

### DIFF
--- a/brain-marks.xcodeproj/project.pbxproj
+++ b/brain-marks.xcodeproj/project.pbxproj
@@ -177,6 +177,7 @@
 		DBF50B51272467CF000D8B25 /* ContributorsListView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContributorsListView.swift; sourceTree = "<group>"; };
 		DBF50B52272467CF000D8B25 /* SettingsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		DBF50B53272467CF000D8B25 /* SettingsViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsViewModel.swift; sourceTree = "<group>"; };
+		DC36F1F728FD9DA000A6F0B9 /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
 		ECA1CF04DB754255822691F2 /* amplifyconfiguration.json */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; path = amplifyconfiguration.json; sourceTree = "<group>"; };
 		FF21986E269FE57D00FFB406 /* AsyncImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncImage.swift; sourceTree = "<group>"; };
 		FF36B660262357F9007A6D7F /* AWSCategory+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AWSCategory+Extension.swift"; sourceTree = "<group>"; };
@@ -647,6 +648,7 @@
 				de,
 				fr,
 				id,
+				es,
 			);
 			mainGroup = FFEBBB2D26223F75000F475F;
 			packageReferences = (
@@ -840,6 +842,7 @@
 				DB8D63FA2767B83B0065A429 /* en */,
 				D3CD6EE028E92BD700F5EC76 /* fr */,
 				A17404B028F8F9D000D292D4 /* id */,
+				DC36F1F728FD9DA000A6F0B9 /* es */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";

--- a/brain-marks/Localization/es.lproj/Localizable.strings
+++ b/brain-marks/Localization/es.lproj/Localizable.strings
@@ -1,0 +1,58 @@
+/* 
+  Localizable.strings
+  brain-marks
+
+  Created by Joel Sereno 10/17/2022
+  
+*/
+
+// TabView
+"Tweets" = "Tweets";
+"Settings" = "Ajustes";
+
+// CategoryViews
+"Categories" = "Categorías";
+"CategoriesAreEmpty" = "Las categorías están vacías,";
+"PleaseAddNewCategories" = "Por favor agregue nuevas categorías haciendo clic en";
+"YouHaventCreatedCategories" = "¡No has creado ninguna categoría!";
+"Edit" = "Editar";
+"Done" = "Hecho";
+"AllCategoriesWillBeDeleted" = "Todas las categorías y todos los tweets serán eliminados";
+"EnterCategoryName" = "Introduzca el nombre de la nueva categoría";
+"Cancel" = "Cancelar";
+"NewCategory" = "Nueva Categoría";
+"EditCategory" = "Editar Categoría";
+"Create" = "Crear";
+"Delete" = "Borrar";
+
+// TweetViews
+"9:58 PM・9/5/20・" = "21:58・5/9/20・";
+"TwitterForIphone" = "Twitter para iPhone";
+"Likes" = "Gustos";
+"NoSavedTweets" = "No hay tweets guardados!";
+"EnteredLinkIsNotValid" = "El enlace que ingresaste no es válido.";
+"UhOh" = "Oh, oh!";
+"YouMustSelectCategory" = "Deba seleccionar una categoría";
+
+// AddURLView
+"EnterCopiedURL" = "Introduzca la URL copiada";
+"Category" = "Categoría";
+"Save" = "Guardar";
+"AddTweetURL" = "Añadir URL de tweet";
+
+// SettingsView
+"Settings" = "Configuración";
+"BrainMarksIsOpenSource" = "¡Brain Marks es un proyecto de código abierto! Fue creado durante el Big Brain Hackathon y ha seguido siendo de código abierto para Hacktoberfest.\nPuede clasificar sus tweets guardados.";
+"IfYouWantToContribute" = "¡Puedes contribuir a este proyecto!\nEste proyecto es de código abierto en GitHub. Visite el siguiente enlace para contribuir. Tenemos una lista de todos los contribuyentes, ¡su nombre podría estar allí!";
+"ListOfContributors" = "Lista de Colaboradores";
+"Links" = "Enlaces";
+"ReportABug" = "Reportar un error";
+"GitHubRepo" = "GitHub Repositorio";
+"ThanksForUsing" = "Gracias por usar";
+"Version" = "Versión";
+"About" = "Acerca de";
+"Contributions" = "Contribuciones";
+"Appearance" = "Apariencia";
+
+// ContributorListView
+"Contributors" = "Colaboradores";

--- a/brain-marks/Localization/es.lproj/Localizable.strings
+++ b/brain-marks/Localization/es.lproj/Localizable.strings
@@ -8,7 +8,7 @@
 
 // TabView
 "Tweets" = "Tweets";
-"Settings" = "Ajustes";
+"Settings" = "Configuración";
 
 // CategoryViews
 "Categories" = "Categorías";


### PR DESCRIPTION
Add Spanish localization to project. 

Closed issue #135 

## What it Does
This adds Spanish localization to the app.

## How I Tested
1. Edit Scheme language to Spanish 
2. Ran the BrainMarks app in Simulator and reviewed Spanish translations

## Notes

1. The settings view was recently updated with section headers, so this was added for Spanish localization.  This will have to be updated for the other languages.
 
2. The names of the new app icons are  in English. I wasn't sure if those should be in Spanish as well or not, but I also did not figure out how to change them even if I wanted to. 

3. Although there is a 'Latin America' subset of Spanish localization available (es-419), I do not think that it was needed for this app.  I ran the simulator with es-419 (vs es) and verified Spanish settings were still all there. 

## Screenshot
Added a screenshot of the settings view with Spanish translations in use.

![Simulator Screen Shot - iPhone 14 Pro - 2022-10-18 at 22 21 59](https://user-images.githubusercontent.com/6628293/196604104-363feda6-a1ef-4b5f-a2c7-b3e5924f2142.png)
