### PR TITLE
Implemented Whats New view from Settings

### DIFF
--- a/brain-marks.xcodeproj/project.pbxproj
+++ b/brain-marks.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		2A7C408628EFCC3600F73DF5 /* BrainMarksWidgets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A7C408528EFCC3600F73DF5 /* BrainMarksWidgets.swift */; };
 		2A7C408828EFCC3700F73DF5 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2A7C408728EFCC3700F73DF5 /* Assets.xcassets */; };
 		2A7C408C28EFCC3700F73DF5 /* BrainMarksWidgetsExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 2A7C407E28EFCC3600F73DF5 /* BrainMarksWidgetsExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		2AC055622908408D00F2919F /* WhatsNewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AC055612908408D00F2919F /* WhatsNewView.swift */; };
 		45B4425428EF5AC800FB0B27 /* AppIconSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B4425328EF5AC800FB0B27 /* AppIconSettings.swift */; };
 		45B4426628EF5EA300FB0B27 /* 8 Rainbow.png in Resources */ = {isa = PBXBuildFile; fileRef = 45B4425628EF5EA300FB0B27 /* 8 Rainbow.png */; };
 		45B4426828EF5EA300FB0B27 /* 4 Beach.png in Resources */ = {isa = PBXBuildFile; fileRef = 45B4425828EF5EA300FB0B27 /* 4 Beach.png */; };
@@ -131,6 +132,7 @@
 		2A7C408528EFCC3600F73DF5 /* BrainMarksWidgets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrainMarksWidgets.swift; sourceTree = "<group>"; };
 		2A7C408728EFCC3700F73DF5 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		2A7C408928EFCC3700F73DF5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		2AC055612908408D00F2919F /* WhatsNewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhatsNewView.swift; sourceTree = "<group>"; };
 		45B4425328EF5AC800FB0B27 /* AppIconSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconSettings.swift; sourceTree = "<group>"; };
 		45B4425628EF5EA300FB0B27 /* 8 Rainbow.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "8 Rainbow.png"; sourceTree = "<group>"; };
 		45B4425828EF5EA300FB0B27 /* 4 Beach.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "4 Beach.png"; sourceTree = "<group>"; };
@@ -376,6 +378,7 @@
 				DBF50B51272467CF000D8B25 /* ContributorsListView.swift */,
 				DB64F8A627270A9B00361E86 /* ContributorProfileView.swift */,
 				45B4427628EF601600FB0B27 /* AppIconListView.swift */,
+				2AC055612908408D00F2919F /* WhatsNewView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -778,6 +781,7 @@
 				FFEBBB3A26223F75000F475F /* brain_marksApp.swift in Sources */,
 				CA80832580B84CB3A2D5F629 /* AmplifyModels.swift in Sources */,
 				DBF50B56272467CF000D8B25 /* SettingsViewModel.swift in Sources */,
+				2AC055622908408D00F2919F /* WhatsNewView.swift in Sources */,
 				75C999F627518708000B0FF8 /* Media.swift in Sources */,
 				C0DAFC52B24C456EAE5AEF21 /* AWSCategory.swift in Sources */,
 				684E2F2D3FCC4D36AC68E57D /* AWSCategory+Schema.swift in Sources */,

--- a/brain-marks/AmplifyModelExtensions/AWSTweet+Extension.swift
+++ b/brain-marks/AmplifyModelExtensions/AWSTweet+Extension.swift
@@ -81,4 +81,3 @@ extension AWSTweet {
             userVerified: false)
     ]
 }
-

--- a/brain-marks/Settings/Views/SettingsView.swift
+++ b/brain-marks/Settings/Views/SettingsView.swift
@@ -37,6 +37,16 @@ struct SettingsView<ViewModel: InfoViewModel>: View {
                             }
                         }
                     }
+
+                    Section(header: Text("Updates")) {
+                        NavigationLink {
+                          WhatsNewView()
+                        } label: {
+                            HStack {
+                                Text("What's New")
+                            }
+                        }
+                    }
                     
                     Section(header: Text("Appearance")) {
                         NavigationLink {

--- a/brain-marks/Settings/Views/WhatsNewView.swift
+++ b/brain-marks/Settings/Views/WhatsNewView.swift
@@ -1,0 +1,29 @@
+//
+//  WhatsNewView.swift
+//  brain-marks
+//
+//  Created by Susannah Skyer Gupta on 10/25/22.
+//
+
+import SwiftUI
+
+struct WhatsNewView: View {
+    var body: some View {
+      VStack(alignment: .leading, spacing: 10) {
+          Text("**v1.2**")
+          .font(.title3)
+          Text("* Delightful updates arriving soon!")
+          Text("**v1.1**")
+          .font(.title3)
+          Text("* Fix add folder and add tweet button not working in iOS 15")
+      }
+      .padding()
+      Spacer()
+    }
+}
+
+struct WhatsNewView_Previews: PreviewProvider {
+    static var previews: some View {
+        WhatsNewView()
+    }
+}


### PR DESCRIPTION
Closes issue #163 

## What it Does
* Adds a simple, hard-coded What's New view to the Settings Page so users can see the change history in the app without needing to go to the App Store listing

## How I Tested
* Launch app in simulator.
* Tap Settings tab.
* Tap new What's New row in new UPDATES section.
* Behold the beautiful new and informative changelog.

## Notes
* Using Markdown plus the font modifier is perhaps overkill, but the issue said use Markdown, so I went with it.
* The change to `AWSTweet+Extension.swift` was to resolve a SwiftLint trailing whitespace warning.
## Screenshot

https://user-images.githubusercontent.com/5115383/197837693-efd05153-b922-4d3c-a9ec-fecd925b472a.mp4

