### PR TITLE
setting contributors on main thread

### DIFF
--- a/brain-marks/Settings/SettingsViewModel.swift
+++ b/brain-marks/Settings/SettingsViewModel.swift
@@ -46,7 +46,9 @@ class SettingsViewModel: ObservableObject {
                 
                 let data = try JSONDecoder().decode([Contributor].self, from: urlData!)
                 
-                self.contributors = data
+                DispatchQueue.main.async {
+                    self.contributors = data
+                }
                 
             } catch {
                 Logger.network.error("\(error)")


### PR DESCRIPTION
Progress / Closed on issue #171

## What it Does
Sets contributors in SettingsViewModel on main thread.

## How I Tested
- Clicked into contributors view and warning does not pop up

## Notes
no

## Screenshot
Was just a code change no visual change